### PR TITLE
This should fix Errors like:

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,10 @@ class grafana (
   $timezone_offset    = '0000',
   $playlist_timespan  = '1m'
 ) {
+  Exec {
+    path => [ '/bin', '/usr/bin', '/usr/local/bin' ],
+    cwd  => '/',
+  }
 
   # The anchor resources allow the end user to establish relationships
   # to the "main" class and preserve the relationship to the


### PR DESCRIPTION
```
Error: Failed to apply catalog: Validation of Exec[Download Grafana]
failed: 'curl -s -L
http://grafanarel.s3.amazonaws.com/grafana-1.6.1.tar.gz | tar xz' is not
qualified and no path was specified. Please qualify the command or
specify a path. at /puppet/modules/grafana/manifests/install.pp:17
Wrapped exception:
'curl -s -L http://grafanarel.s3.amazonaws.com/grafana-1.6.1.tar.gz |
tar xz' is not qualified and no path was specified. Please qualify the
command or specify a path.
```
