### PR TITLE
Enable influxDB storage backend for Grafana

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,8 @@ class grafana (
   $influxdb_dbpath    = '/db/grafana',
   $influxdb_user      = 'grafana',
   $influxdb_pass      = 'grafana',
+  $influxdb_grafana_user      = 'grafana',
+  $influxdb_grafana_pass      = 'grafana',
   $timezone_offset    = '0000',
   $playlist_timespan  = '1m'
 ) {

--- a/templates/config.js.erb
+++ b/templates/config.js.erb
@@ -19,12 +19,20 @@ function (Settings) {
         default: true
       },
     <% end %>
+
     <% if scope.lookupvar('grafana::influxdb_host') != '' -%>
       influxdb: {
         type: 'influxdb',
         url: "http:/<%= scope.lookupvar('grafana::influxdb_host') %>:<%= scope.lookupvar('grafana::influxdb_port') %><%= scope.lookupvar('grafana::influxdb_dbpath') %>",
         username: '<%= scope.lookupvar('grafana::influxdb_user') %>',
         password: '<%= scope.lookupvar('grafana::influxdb_pass') %>'
+      },
+      'grafana': {
+          type: 'influxdb',
+          url: "http:/<%= scope.lookupvar('grafana::influxdb_host') %>:<%= scope.lookupvar('grafana::influxdb_port') %>/db/grafana",
+          username: '<%= scope.lookupvar('grafana::influxdb_grafana_user') %>',
+          password: '<%= scope.lookupvar('grafana::influxdb_grafana_pass') %>'
+          grafanaDB: true
       },
     <% end %>
     },


### PR DESCRIPTION
You can use InfluxDB Grafana to store dashboards.
grafanaDB: true marks it for use as dashboard storage (applicable for
InfluxDB & Elasticsearch)
