### PR TITLE
Added ElasticSearch Index Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ Default is '' (empty)
 Port of elasticsearch service.
 Default is 9200
 
+#####`elasticsearch_index`
+
+Name of elasticsearch index.
+Default is 'grafana-dash;
+
 #####`opentsdb_scheme`
 
 Scheme of OpenTSDB service.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,9 @@
 # [*elasticsearch_port*]
 #   Port of elasticsearch service.
 #   Default is 9200
+# [*elasticsearch_index*]
+#   Name of elasticsearch index.
+#   Default is 'grafana-dash'
 # [*opentsdb_scheme*]
 #   Scheme of OpenTSDB service.
 #   Default is 'http'
@@ -85,6 +88,7 @@ class grafana (
   $elasticsearch_scheme  = 'http',
   $elasticsearch_host    = '',
   $elasticsearch_port    = 9200,
+  $elasticsearch_index   = 'grafana-dash',
   $opentsdb_scheme       = 'http',
   $opentsdb_host         = '',
   $opentsdb_port         = 4242,

--- a/templates/config.js.erb
+++ b/templates/config.js.erb
@@ -23,7 +23,7 @@ function (Settings) {
       elasticsearch: {
         type: 'elasticsearch',
         url: "<%= scope.lookupvar('grafana::elasticsearch_scheme') %>://<%= scope.lookupvar('grafana::elasticsearch_host') %>:<%= scope.lookupvar('grafana::elasticsearch_port') %>",
-        index: 'grafana-dash',
+        index: '<%= scope.lookupvar('grafana::elasticsearch_index') %>',
         grafanaDB: true,
       },
     <% end -%>


### PR DESCRIPTION
Added ElasticSearch Index variable to avoid having a  hardcoded name inside this module. This will allow multiple installations of Grafana. Default name remains the same.

Thanks.